### PR TITLE
Input for docs

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -5,8 +5,8 @@ Configuration
 
 Two configuration files are required:
 
-- ``motley_cue.conf``: contains configuration options relating to `authorisation`.
-- ``feudal_adapter.conf``: contains configuration options relating to the `account creation`.
+- ``motley_cue.conf``: contains configuration options relating to `authorisation`_.
+- ``feudal_adapter.conf``: contains configuration options relating to the `account creation`_.
 
 
 Configuration templates
@@ -87,7 +87,7 @@ Below, a configuration block for one OP with default values.
 
 - The section name has to start with ``authorisation.``
 - The OP URL must be specified
-- A VO must be specified as a string or an entitlement according to the AARC guideline `AARC-G002 <https://aarc-community.org/guidelines/aarc-g002>`_
+- A VO must be specified as a string or an entitlement according to the AARC guideline `AARC-G002 <https://aarc-community.org/guidelines/aarc-g002>`_ (or `AARC-G069 <https://aarc-community.org/guidelines/aarc-g069>`_, once it is published)
 - An individual user must be specified by its unique identifier at the OP (the ``sub`` claim)
 
 

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -5,8 +5,8 @@ Configuration
 
 Two configuration files are required:
 
-- ``motley_cue.conf``: contains configuration options specific to the REST API
-- ``feudal_adapter.conf``: contains configuration options for the `feudalAdapter <https://git.scc.kit.edu/feudal/feudalAdapterLdf>`_
+- ``motley_cue.conf``: contains configuration options relating to `authorisation`.
+- ``feudal_adapter.conf``: contains configuration options relating to the `account creation`.
 
 
 Configuration templates
@@ -89,6 +89,9 @@ Below, a configuration block for one OP with default values.
 - The OP URL must be specified
 - A VO must be specified as a string or an entitlement according to the AARC guideline `AARC-G002 <https://aarc-community.org/guidelines/aarc-g002>`_
 - An individual user must be specified by its unique identifier at the OP (the ``sub`` claim)
+
+
+.. _account creation:
 
 Account creation configuration
 -------------------------------

--- a/doc/source/running.rst
+++ b/doc/source/running.rst
@@ -36,6 +36,7 @@ Production
 ----------
 
 This section describes how to run ``motley_cue`` in production if you installed it with ``pip``.
+If you used the package, these configuration options are already applied.
 
 To set up the production environment, we recommended using:
 
@@ -45,6 +46,8 @@ To set up the production environment, we recommended using:
 
 
 The code examples below assume a python virtualenv at ``/usr/lib/motley-cue``, where you have installed ``motley_cue`` and its dependencies. Adapt paths if necessary.
+
+Templates for all referred configuration files are provided with either the package or the ``pip`` installation.
 
 ..
  You can change the port and other nginx settings by editing ``/etc/nginx/sites-enabled/nginx.motley_cue``.
@@ -98,7 +101,7 @@ Copy it to the appropriate location (e.g. ``/etc/nginx/sites-enabled/nginx.motle
 Config files
 ^^^^^^^^^^^^
 
-This is a list of the required configuration files, which are usually present when you install ``motley_cue`` with a package manager:
+This is the list of the required configuration files, which are usually present when you install ``motley_cue`` with a package manager:
 
 .. toctree::
     :maxdepth: 1

--- a/doc/source/ssh-integration.rst
+++ b/doc/source/ssh-integration.rst
@@ -15,6 +15,8 @@ You can also install it from the http://repo.data.kit.edu/ repo:
 .. code-block:: bash
 
     apt-get install pam-ssh-oidc
+    or
+    yum install pam-ssh-oidc
 
 
 Check out the documentation for how to configure it. Make sure you set SSH to use the PAM module.

--- a/doc/source/ssh-integration.rst
+++ b/doc/source/ssh-integration.rst
@@ -44,6 +44,8 @@ Finally, make sure you have in your ``/etc/ssh/sshd_config``:
     ChallengeResponseAuthentication yes
     UsePam yes
 
+Note that this may enable password based logins that you need to disable separately.
+
 Client
 ------
 

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -13,7 +13,7 @@ First, you'll need an OIDC AccessToken to authenticate.
 
 You might want to check out the `oidc-agent <https://github.com/indigo-dc/oidc-agent>`_ for that. It is a daemon that can provide valid access tokens from any number of configured OIDC Providers (OPs).
 
-Once you get the ``oidc-agent`` running, configure an account for your preferred OP. For example, you can generate an account configuration for the `EGI AAI <https://aai.egi.eu/oidc>`_  named ``egi`` as follows: 
+Once you have ``oidc-agent`` running, configure an account for your preferred OP. For example, you can generate an account configuration for the `EGI AAI <https://aai.egi.eu/oidc>`_  named ``egi`` as follows: 
 
 .. code-block:: bash
 
@@ -24,6 +24,8 @@ Then you can retrieve an access token with:
 .. code-block:: bash
 
   oidc-token egi
+
+There are `oidc-agent gitbook pages <https://indigo-dc.gitbook.io/oidc-agent/user/oidc-gen/provider>` that provide detailed information for creating account configurations with many other OPs.
 
 If you have another way to retrieve OIDC access tokens, don't worry. You can pass the token directly.
 


### PR DESCRIPTION
Probably the swagger interface should be removed for production. At least
the docs should say how to do it.

I'm not sure if this is a security thing. (And usually anything which is
not strictly necessary is disabled, when it comes to the sec folks.)


I have no idea how to disable the ssh-passwords separately (as I recommend
in the docs now).