### PR TITLE
Long tokens

### DIFF
--- a/doc/source/api/openapi.yml
+++ b/doc/source/api/openapi.yml
@@ -2,7 +2,7 @@ openapi: 3.0.2
 info:
   title: motley_cue
   description: A service for mapping OIDC identities to local identities
-  version: 0.1.6
+  version: 0.3.0
 paths:
   /user:
     get:
@@ -202,6 +202,68 @@ paths:
             application/json:
               schema:
                 title: Response 404 Suspend User Suspend Get
+                anyOf:
+                  - $ref: '#/components/schemas/ClientError'
+                  - $ref: '#/components/schemas/FlaatError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - HTTPBearer: []
+  /user/generate_otp:
+    get:
+      tags:
+        - user
+      summary: Generate Otp
+      description: 'Generates and stores a new one-time password, using token as shared
+        secret.
+
+
+        Requires an authorised user.'
+      operationId: generate_otp_user_generate_otp_get
+      parameters:
+        - description: OIDC Access Token
+          required: true
+          schema:
+            title: Authorization
+            type: string
+            description: OIDC Access Token
+          name: Authorization
+          in: header
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OTPResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                title: Response 401 Generate Otp User Generate Otp Get
+                anyOf:
+                  - $ref: '#/components/schemas/ClientError'
+                  - $ref: '#/components/schemas/FlaatError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                title: Response 403 Generate Otp User Generate Otp Get
+                anyOf:
+                  - $ref: '#/components/schemas/ClientError'
+                  - $ref: '#/components/schemas/FlaatError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                title: Response 404 Generate Otp User Generate Otp Get
                 anyOf:
                   - $ref: '#/components/schemas/ClientError'
                   - $ref: '#/components/schemas/FlaatError'
@@ -515,12 +577,12 @@ paths:
             description: username to compare to local username
           name: username
           in: query
-        - description: OIDC Access Token
+        - description: OIDC Access Token or valid one-time token
           required: true
           schema:
             title: Authorization
             type: string
-            description: OIDC Access Token
+            description: OIDC Access Token or valid one-time token
           name: Authorization
           in: header
       responses:
@@ -675,6 +737,30 @@ components:
           default: []
           example:
             - /wlcg
+        audience:
+          title: Audience
+          anyOf:
+            - type: string
+            - type: array
+              items:
+                type: string
+          default: ''
+          example: ssh_localhost
+    OTPResponse:
+      title: OTPResponse
+      required:
+        - supported
+      type: object
+      properties:
+        supported:
+          title: Supported
+          type: boolean
+          example: true
+        successful:
+          title: Successful
+          type: boolean
+          default: false
+          example: true
     ValidationError:
       title: ValidationError
       required:

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -120,6 +120,37 @@ Pay close attention to the following configurations:
 Additional configurations
 -------------------------
 
+.. rubric:: One-time tokens
+
+To enable SSH support for large access tokens (longer than 1k), you can enable the use of one-time tokens in the ``[mapper.otp]`` section in ``motley_cue.conf``.
+
+Calling the ``/user/generate_otp`` endpoint will generate a shorter, one-time token and store it in a local, encrypted database. This token can then be used as an SSH password instead of the access token, and the ``/verify_user`` will be able to verify the username with this one-time token by retrieving the corresponding access token from the database.
+
+You can also configure the location of the token database, the backend used, as well as the location of the encryption key.
+
+.. code-block:: ini
+
+  ############
+  [mapper.otp]
+  ############
+  ## use one-time passwords (OTP) instead of tokens as ssh password -- default: False
+  ## this can be used when access tokens are too long to be used as passwords (>1k)
+  use_otp = True
+  ##
+  ## backend for storing the OTP-AT mapping -- default: sqlite
+  ## supported backends: sqlite, sqlitedict, shelve
+  # backend = sqlite
+  ##
+  ## location for storing token database -- default: /run/motley_cue/tokenmap.db
+  # db_location = /run/motley_cue/tokenmap.db
+  ## path to file containing key for encrypting token db -- default: /run/motley_cue/motley_cue.key
+  ## key must be a URL-safe base64-encoded 32-byte key, and it will be created if it doesn't exist
+  ## encryption not supported when using the "shelve" backend
+  # keyfile = /run/motley_cue/motley_cue.key
+
+
+.. rubric:: Swagger docs
+
 By default, the Swagger documentation for the REST API is disabled. You can enable it in ``motley_cue.conf``, and change its location:
 
 .. code-block:: ini

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -138,14 +138,13 @@ You can also configure the location of the token database, the backend used, as 
   use_otp = True
   ##
   ## backend for storing the OTP-AT mapping -- default: sqlite
-  ## supported backends: sqlite, sqlitedict, shelve
+  ## supported backends: sqlite, sqlitedict
   # backend = sqlite
   ##
   ## location for storing token database -- default: /run/motley_cue/tokenmap.db
   # db_location = /run/motley_cue/tokenmap.db
   ## path to file containing key for encrypting token db -- default: /run/motley_cue/motley_cue.key
   ## key must be a URL-safe base64-encoded 32-byte key, and it will be created if it doesn't exist
-  ## encryption not supported when using the "shelve" backend
   # keyfile = /run/motley_cue/motley_cue.key
 
 

--- a/etc/gunicorn.conf.py
+++ b/etc/gunicorn.conf.py
@@ -35,6 +35,8 @@ use_errorlog = errorlog_var or None
 graceful_timeout_str = os.getenv("GRACEFUL_TIMEOUT", "120")
 timeout_str = os.getenv("TIMEOUT", "120")
 keepalive_str = os.getenv("KEEP_ALIVE", "5")
+max_requests_str = os.getenv("MAX_REQUESTS", "0")
+max_requests_jitter_str = os.getenv("MAX_REQUESTS_JITTER", "0")
 
 # Gunicorn config variables
 loglevel = use_loglevel
@@ -46,7 +48,8 @@ accesslog = use_accesslog
 graceful_timeout = int(graceful_timeout_str)
 timeout = int(timeout_str)
 keepalive = int(keepalive_str)
-
+max_requests = int(max_requests_str)
+max_requests_jitter = int(max_requests_jitter_str)
 
 # For debugging and testing
 log_data = {
@@ -58,6 +61,8 @@ log_data = {
     "keepalive": keepalive,
     "errorlog": errorlog,
     "accesslog": accesslog,
+    "max_requests": max_requests,
+    "max_requests_jitter": max_requests_jitter,
     # Additional, non-gunicorn variables
     "workers_per_core": workers_per_core,
     "use_max_workers": use_max_workers,

--- a/etc/motley_cue.conf
+++ b/etc/motley_cue.conf
@@ -23,13 +23,14 @@ log_level = WARNING
 use_otp = True
 ##
 ## backend for storing the OTP-AT mapping -- default: sqlite
-## supported backends: sqlite, shelve
+## supported backends: sqlite, shelve, sqlitedict
 # backend = sqlite
 ##
 ## location for storing token database -- default: /run/motley_cue/tokenmap.db
-db_location = /tmp/tokenmap.db
-## password for encrypting token db -- default: empty password => not encrypted
-password = set_a_password_here
+# db_location = /run/motley_cue/tokenmap.db
+## path to file containing key for encrypting token db -- default: /run/motley_cue/motley_cue.key
+## key must be a URL-safe base64-encoded 32-byte key, and it will be created if it doesn't exist
+# keyfile = /run/motley_cue/motley_cue.key
 
 
 #########

--- a/etc/motley_cue.conf
+++ b/etc/motley_cue.conf
@@ -129,6 +129,11 @@ op_url = https://aai.egi.eu/oidc
 #     ]
 # authorise_admins_for_all_ops = True
 
+###################
+[authorisation.egi-dev]
+###################
+op_url = https://aai-dev.egi.eu/auth/realms/egi
+
 
 ###################
 [authorisation.wlcg]

--- a/etc/motley_cue.conf
+++ b/etc/motley_cue.conf
@@ -20,16 +20,17 @@ log_level = WARNING
 ############
 ## use one-time passwords (OTP) instead of tokens as ssh password -- default: False
 ## this can be used when access tokens are too long to be used as passwords (>1k)
-use_otp = True
+# use_otp = False
 ##
 ## backend for storing the OTP-AT mapping -- default: sqlite
-## supported backends: sqlite, shelve, sqlitedict
+## supported backends: sqlite, sqlitedict, shelve
 # backend = sqlite
 ##
 ## location for storing token database -- default: /run/motley_cue/tokenmap.db
 # db_location = /run/motley_cue/tokenmap.db
 ## path to file containing key for encrypting token db -- default: /run/motley_cue/motley_cue.key
 ## key must be a URL-safe base64-encoded 32-byte key, and it will be created if it doesn't exist
+## encryption not supported when using the "shelve" backend
 # keyfile = /run/motley_cue/motley_cue.key
 
 

--- a/etc/motley_cue.conf
+++ b/etc/motley_cue.conf
@@ -23,14 +23,13 @@ log_level = WARNING
 # use_otp = False
 ##
 ## backend for storing the OTP-AT mapping -- default: sqlite
-## supported backends: sqlite, sqlitedict, shelve
+## supported backends: sqlite, sqlitedict
 # backend = sqlite
 ##
 ## location for storing token database -- default: /run/motley_cue/tokenmap.db
 # db_location = /run/motley_cue/tokenmap.db
 ## path to file containing key for encrypting token db -- default: /run/motley_cue/motley_cue.key
 ## key must be a URL-safe base64-encoded 32-byte key, and it will be created if it doesn't exist
-## encryption not supported when using the "shelve" backend
 # keyfile = /run/motley_cue/motley_cue.key
 
 

--- a/etc/motley_cue.conf
+++ b/etc/motley_cue.conf
@@ -23,7 +23,7 @@ log_level = WARNING
 use_otp = True
 ##
 ## backend for storing the OTP-AT mapping -- default: sqlite
-## supported backends: sqlite
+## supported backends: sqlite, shelve
 # backend = sqlite
 ##
 ## location for storing token database -- default: /run/motley_cue/tokenmap.db

--- a/etc/motley_cue.conf
+++ b/etc/motley_cue.conf
@@ -15,6 +15,22 @@ log_level = WARNING
 ## location of swagger docs -- default: /docs
 # docs_url = /docs
 
+############
+[mapper.otp]
+############
+## use one-time passwords (OTP) instead of tokens as ssh password -- default: False
+## this can be used when access tokens are too long to be used as passwords (>1k)
+use_otp = True
+##
+## backend for storing the OTP-AT mapping -- default: sqlite
+## supported backends: sqlite
+# backend = sqlite
+##
+## location for storing token database -- default: /run/motley_cue/tokenmap.db
+db_location = /tmp/tokenmap.db
+## password for encrypting token db -- default: empty password => not encrypted
+password = set_a_password_here
+
 
 #########
 [DEFAULT]

--- a/etc/motley_cue.env
+++ b/etc/motley_cue.env
@@ -3,3 +3,5 @@ ACCESS_LOG=/var/log/motley_cue/motley_cue.gunicorn.access
 BIND=unix:/run/motley_cue/motley-cue.sock
 LOG_LEVEL_GUNICORN=info
 FEUDAL_ADAPTER_CONFIG=/etc/motley_cue/feudal_adapter.conf
+MAX_REQUESTS=1000
+MAX_REQUESTS_JITTER=50

--- a/motley_cue/api.py
+++ b/motley_cue/api.py
@@ -104,7 +104,11 @@ async def verify_user(
         ...,
         description="username to compare to local username",
     ),
-    header: str = Header(..., alias="Authorization", description="OIDC Access Token"),
+    header: str = Header(
+        ...,
+        alias="Authorization",
+        description="OIDC Access Token or valid one-time token",
+    ),
 ):  # pylint: disable=unused-argument
     """Verify that the authenticated user has a local account with the given **username**.
 

--- a/motley_cue/api.py
+++ b/motley_cue/api.py
@@ -78,7 +78,7 @@ async def info():
 @mapper.authenticated_user_required
 async def info_authorisation(
     request: Request,
-    token: str = Header(..., alias="Authorization", description="OIDC Access Token"),
+    header: str = Header(..., alias="Authorization", description="OIDC Access Token"),
 ):  # pylint: disable=unused-argument
     """Retrieve authorisation information for specific OP.
 
@@ -96,6 +96,7 @@ async def info_authorisation(
     response_model=VerifyUser,
     responses={**responses, 200: {"model": VerifyUser}},
 )
+@mapper.inject_token
 @mapper.authorised_user_required
 async def verify_user(
     request: Request,
@@ -103,7 +104,7 @@ async def verify_user(
         ...,
         description="username to compare to local username",
     ),
-    token: str = Header(..., alias="Authorization", description="OIDC Access Token"),
+    header: str = Header(..., alias="Authorization", description="OIDC Access Token"),
 ):  # pylint: disable=unused-argument
     """Verify that the authenticated user has a local account with the given **username**.
 

--- a/motley_cue/mapper/config.py
+++ b/motley_cue/mapper/config.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 import logging
 import os
 from pathlib import Path
+from dataclasses import dataclass
 
 from flaat.requirements import (
     IsTrue,
@@ -32,21 +33,26 @@ class Config:
         Raises:
             InternalException: if configuration does not contain mandatory section [mapper]
         """
-        try:
+        if config_parser.has_section("mapper"):
             config_mapper = config_parser["mapper"]
-        except Exception as ex:
+        else:
             raise InternalException(
                 "No [mapper] configuration found in configuration file!"
-            ) from ex
+            )
         # log level
         self.__log_level = config_mapper.get("log_level", logging.WARNING)
         # log file
         self.__log_file = config_mapper.get("log_file", None)
         # swagger docs
-        if config_mapper.get("enable_docs", False):
+        if to_bool(config_mapper.get("enable_docs", "False")):
             self.__docs_url = config_mapper.get("docs_url", "/docs")
         else:
             self.__docs_url = None
+        # use OTPs as a replacement for long (>1k) access tokens
+        otp_dict = {}
+        if config_parser.has_section("mapper.otp"):
+            otp_dict = dict(config_parser["mapper.otp"])
+        self.__otp = OTPConfig(otp_dict)
         # trusted OPs
         authz_sections = [
             section
@@ -91,6 +97,11 @@ class Config:
     def docs_url(self):
         """return url to be used as location for swagger docs"""
         return self.__docs_url
+
+    @property
+    def otp(self):
+        """Return whether OTPs are enabled"""
+        return self.__otp
 
     @property
     def verbosity(self):
@@ -283,3 +294,20 @@ class OPAuthZ:
             return IsTrue(user_has_sub)
 
         return Unsatisfiable()
+
+
+@dataclass
+class OTPConfig:
+    """Class describing the OTP configuration"""
+
+    def __init__(self, otp_config: dict) -> None:
+        """Initialises all fields from given dict or with default values,
+        and converts them to the appropriate type when necessary.
+
+        Args:
+            otp_config (dict): ConfigParser section for OTP
+        """
+        self.use_otp = to_bool(otp_config.get("use_otp", "False"))
+        self.backend = otp_config.get("backend", "sqlite").lower()
+        self.db_location = otp_config.get("db_location", "/run/motley_cue/tokenmap.db")
+        self.password = otp_config.get("password", "")

--- a/motley_cue/mapper/config.py
+++ b/motley_cue/mapper/config.py
@@ -310,4 +310,4 @@ class OTPConfig:
         self.use_otp = to_bool(otp_config.get("use_otp", "False"))
         self.backend = otp_config.get("backend", "sqlite").lower()
         self.db_location = otp_config.get("db_location", "/run/motley_cue/tokenmap.db")
-        self.password = otp_config.get("password", "")
+        self.keyfile = otp_config.get("keyfile", "/run/motley_cue/motley_cue.key")

--- a/motley_cue/mapper/token_manager.py
+++ b/motley_cue/mapper/token_manager.py
@@ -1,0 +1,227 @@
+from typing import Callable, Optional
+import hashlib
+import logging
+from functools import wraps
+import sqlite3
+from sqlcipher3 import dbapi2 as sqlcipher
+
+from .config import OTPConfig
+
+logger = logging.getLogger(__name__)
+
+
+class TokenDB:
+    """Generic database for mapping of short-lived / one-time-use tokens to access tokens
+    Following methods must be implemented: get, insert, delete.
+    """
+
+    def pop(self, otp: str) -> Optional[str]:
+        """Implement one-time logic by removing mapping on get."""
+        token = self.get(otp)
+        if token:
+            self.delete(otp)
+        return token
+
+    def store_no_collision(self, otp: str, token: str) -> bool:
+        """Do collision checking before inserting mapping to DB.
+        Return True on successful insert. If mapping already existed,
+        insert is also considered successful.
+        """
+        stored_token = self.get(otp)
+        if not stored_token:
+            logger.debug("Storing OTP: %s", otp)
+            return self.insert(otp, token)
+        elif stored_token == token:
+            logger.debug("OTP already exists for token %s", token)
+            return True
+        logger.debug(
+            "Collision error: OTP for token %s collides with OTP for another token",
+            token,
+        )
+        return False
+
+    def get(self, otp: str) -> Optional[str]:
+        """Retrieve access token mapped to given one-time token from db."""
+        return None
+
+    def delete(self, otp: str) -> bool:
+        """Remove mapping for given one-time token from db."""
+        return False
+
+    def insert(self, otp: str, token: str) -> bool:
+        """Insert mapping between given one-time token and access token to db."""
+        return False
+
+
+class DictTokenDB(TokenDB):
+    """Database for mapping of one-time tokens to access tokens using a dict"""
+
+    def __init__(self) -> None:
+        self.__db = {}
+
+    def get(self, otp: str) -> Optional[str]:
+        return self.__db.get(otp, None)
+
+    def insert(self, otp: str, token: str) -> bool:
+        try:
+            self.__db[otp] = token
+            return True
+        except Exception as e:
+            logger.debug("Failed to insert token mapping (%s, %s): %s", (otp, token, e))
+            return False
+
+    def delete(self, otp: str) -> bool:
+        try:
+            del self.__db[otp]
+            return True
+        except Exception as e:
+            logger.debug("Failed to remove token mapping for otp %s: %s", (otp, e))
+            return False
+
+
+class SQLiteTokenDB(TokenDB):
+    """SQLite-based DB for mapping one-time tokens to access tokens"""
+
+    def __init__(self, location: str, password: str) -> None:
+        # new db connection for location (does not need to exist)
+        self.connection = sqlcipher.connect(location)
+        self.connection.execute(f'pragma key="{password}"')
+        with self.connection:  # con.commit() is called automatically afterwards on success
+            # create table
+            self.connection.execute(
+                """create table if not exists tokenmap
+                        (otp text primary key, at text)"""
+            )
+
+    def get(self, otp: str) -> Optional[str]:
+        sql_get = "select at from tokenmap where otp=?"
+        with self.connection:
+            result = self.connection.execute(sql_get, [otp]).fetchall()
+        if len(result) == 0:
+            return None
+        if len(result) > 1:
+            logger.warning("Multiple entries found in token db for OTP: %s", otp)
+        return result[0][0]
+
+    def delete(self, otp: str) -> bool:
+        try:
+            sql_del = "delete from tokenmap where otp=?"
+            with self.connection:
+                self.connection.execute(sql_del, [otp])
+            return True
+        except sqlite3.Error as e:
+            logger.debug("Failed to remove token mapping for otp %s: %s", (otp, e))
+            return False
+
+    def insert(self, otp: str, token: str) -> bool:
+        try:
+            sql_insert = "insert into tokenmap(otp, at) values (?,?)"
+            with self.connection:
+                self.connection.execute(sql_insert, (otp, token))
+            return True
+        except sqlite3.Error as e:
+            logger.debug("Failed to insert token mapping (%s, %s): %s", (otp, token, e))
+            return False
+
+
+class TokenManager:
+    """Class to manage short lived & short tokens:
+
+    - useful for long tokens (>1k)
+    - maps ATs to OTPs (shorter, short-lived tokens)
+    - generates OTP by hashing the AT
+    - stores mapping OTP <-> AT in a secure db (or in memory??)
+        - this is done on /user/generate_otp
+    - use OTP as ssh password
+        - on /verify_user, OTP is translated to AT and then we go forward with authorisation & usual verification
+    - security:
+        - either one-time use (remove mapping once it is used)
+        - or expiration after a certain time
+    """
+
+    def __init__(self, otp_config: OTPConfig) -> None:
+        """Any DB-related initialisations"""
+        if otp_config.backend == "sqlite":
+            self.__db = SQLiteTokenDB(otp_config.db_location, otp_config.password)
+        elif otp_config.backend == "memory":
+            self.__db = DictTokenDB()
+
+    @classmethod
+    def from_config(cls, otp_config: OTPConfig):
+        if otp_config.use_otp:
+            return cls(otp_config)
+        return None
+
+    def _new_otp(self, token: str) -> Optional[str]:
+        """Create a new OTP by hashing given token."""
+        try:
+            return hashlib.sha512(bytearray(token, "ascii")).hexdigest()
+        except Exception:
+            return None
+
+    def get_token(self, otp: str) -> Optional[str]:
+        """Retrieve the token associated to this OTP from token DB."""
+        return self.__db.pop(otp)
+
+    def generate_otp(self, token: str) -> dict:
+        """Generate and store a new OTP for given token."""
+        otp = self._new_otp(token)
+        if otp:
+            success = self.__db.store_no_collision(otp, token)
+        else:
+            success = False
+        return {"supported": True, "successful": success}
+
+    def inject_token(self, func: Callable) -> Callable:
+        """Decorator that replaces the given token (OTP) with its corresponding AT.
+        Only if given token is found in OTP db.
+        Otherwise pass token through as is, and it will be treated like an AT.
+        """
+
+        def _get_token_from_kwargs(kwargs: dict):
+            """Get token from function kwargs, either present in header or request header"""
+            header = None
+            if "header" in kwargs:  # pragma: no cover
+                header = kwargs["header"]
+            if "request" in kwargs:
+                header = kwargs["request"].headers.get("authorization", None)
+            if header and header.startswith("Bearer "):
+                return header.lstrip("Bearer ")
+            return None
+
+        def _replace_token_in_kwargs(kwargs: dict, token: str) -> dict:
+            """If present in kwargs, replace bearer token in authorization request header
+            with given token.
+            """
+            if "header" not in kwargs and "request" not in kwargs:
+                logger.warning("header or request not in kwargs")
+                return kwargs
+
+            if "header" in kwargs and kwargs["header"].startswith("Bearer "):
+                kwargs["header"] = f"Bearer {token}"
+            if "request" in kwargs:
+                authz_header = kwargs["request"].headers.get("authorization", None)
+                if authz_header and authz_header.startswith("Bearer "):
+                    new_headers = kwargs["request"].headers.mutablecopy()
+                    new_headers["authorization"] = f"Bearer {token}"
+                    kwargs["request"]._headers = new_headers
+
+            return kwargs
+
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            otp = _get_token_from_kwargs(kwargs)
+            if otp:
+                logger.debug("Found token in kwargs: %s", otp)
+                at = self.get_token(otp)
+                if at:
+                    logger.debug("OTP %s found in token DB", otp)
+                    kwargs = _replace_token_in_kwargs(kwargs, at)
+                    logger.debug(
+                        "Injected Access Token %s corresponding to given OTP %s",
+                        at,
+                        otp,
+                    )
+            return await func(*args, **kwargs)
+
+        return wrapper

--- a/motley_cue/models.py
+++ b/motley_cue/models.py
@@ -76,6 +76,19 @@ class FeudalResponse:
 
 
 @dataclass
+class OTPResponse:
+    """Data model for any responses coming from TokenManager,
+    on /user/generate_otp.
+    Information on whether OTPs are supported, in which case also
+    whether the OTP generation and storage succeeded.
+    """
+
+    supported: bool = Field(..., example=True)
+    successful: bool = Field(False, example=True)
+    # message: Optional[str] = Field("", example="OTPs not supported.")
+
+
+@dataclass
 class ClientError:
     """Data model for responses on errors."""
 

--- a/motley_cue/routers/admin.py
+++ b/motley_cue/routers/admin.py
@@ -40,7 +40,7 @@ async def read_root():
 @mapper.authorised_admin_required
 async def suspend(
     request: Request,
-    token: str = Header(..., alias="Authorization", description="OIDC Access Token"),
+    header: str = Header(..., alias="Authorization", description="OIDC Access Token"),
     sub: str = Query(
         ...,
         description="sub claim of the user to be suspended",
@@ -71,7 +71,7 @@ async def suspend(
 @mapper.authorised_admin_required
 async def resume(
     request: Request,
-    token: str = Header(..., alias="Authorization", description="OIDC Access Token"),
+    header: str = Header(..., alias="Authorization", description="OIDC Access Token"),
     sub: str = Query(
         ...,
         description="sub claim of the user to be suspended",

--- a/motley_cue/routers/user.py
+++ b/motley_cue/routers/user.py
@@ -26,6 +26,7 @@ async def read_root():
             f"{api.prefix}/get_status": "Get information about your local account.",
             f"{api.prefix}/deploy": "Provision local account.",
             f"{api.prefix}/suspend": "Suspend local account.",
+            f"{api.prefix}/generate_otp": "Generates a one-time token for given access token.",
         },
     }
 

--- a/motley_cue/routers/user.py
+++ b/motley_cue/routers/user.py
@@ -4,7 +4,7 @@ This module contains the definition of motley_cue's user API.
 from fastapi import APIRouter, Request, Depends, Header
 
 from ..dependencies import mapper
-from ..models import FeudalResponse, responses
+from ..models import FeudalResponse, OTPResponse, responses
 
 
 api = APIRouter(prefix="/user")
@@ -40,7 +40,7 @@ async def read_root():
 @mapper.authorised_user_required
 async def get_status(
     request: Request,
-    token: str = Header(..., alias="Authorization", description="OIDC Access Token"),
+    header: str = Header(..., alias="Authorization", description="OIDC Access Token"),
 ):  # pylint: disable=unused-argument
     """Get information about your local account:
 
@@ -62,7 +62,7 @@ async def get_status(
 @mapper.authorised_user_required
 async def deploy(
     request: Request,
-    token: str = Header(..., alias="Authorization", description="OIDC Access Token"),
+    header: str = Header(..., alias="Authorization", description="OIDC Access Token"),
 ):  # pylint: disable=unused-argument
     """Provision a local account.
 
@@ -81,10 +81,29 @@ async def deploy(
 @mapper.authorised_user_required
 async def suspend(
     request: Request,
-    token: str = Header(..., alias="Authorization", description="OIDC Access Token"),
+    header: str = Header(..., alias="Authorization", description="OIDC Access Token"),
 ):  # pylint: disable=unused-argument
     """Suspends a local account.
 
     Requires an authorised user.
     """
     return mapper.suspend(request)
+
+
+@api.get(
+    "/generate_otp",
+    dependencies=[Depends(mapper.user_security)],
+    response_model=OTPResponse,
+    response_model_exclude_unset=True,
+    responses={**responses, 200: {"model": OTPResponse}},
+)
+@mapper.authorised_user_required
+async def generate_otp(
+    request: Request,  # pylint: disable=unused-argument
+    header: str = Header(..., alias="Authorization", description="OIDC Access Token"),
+):
+    """Generates and stores a new one-time password, using token as shared secret.
+
+    Requires an authorised user.
+    """
+    return mapper.generate_otp(request)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flaat>=1.0.0
 fastapi
 uvicorn[standard]
 gunicorn
+sqlcipher3-binary

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ fastapi
 uvicorn[standard]
 gunicorn
 sqlcipher3-binary
+sqlitedict
+cryptography

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ flaat>=1.0.0
 fastapi
 uvicorn[standard]
 gunicorn
-sqlcipher3-binary
 sqlitedict
 cryptography

--- a/tests/configs.py
+++ b/tests/configs.py
@@ -121,6 +121,31 @@ docs_url = docs
 )
 
 
+CONFIG_OTP_NOT_SUPPORTED = load_config(
+    f"""
+{CONFIG_BASE}
+[mapper.otp]
+use_otp = False
+[authorisation.OP]
+op_url = {MOCK_ISS}
+authorise_all = True
+"""
+)
+
+CONFIG_OTP_SUPPORTED = load_config(
+    f"""
+{CONFIG_BASE}
+[mapper.otp]
+use_otp = True
+backend = sqlite
+db_location = /run/motley_cue/tokenmap.db
+keyfile = /run/motley_cue/motley_cue.key
+[authorisation.OP]
+op_url = {MOCK_ISS}
+authorise_all = True
+"""
+)
+
 CONFIGS = {
     "NOT_SUPPORTED": CONFIG_NOT_SUPPORTED,
     "SUPPORTED_NOT_AUTHORISED": CONFIG_SUPPORTED_NOT_AUTHORISED,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,11 +158,8 @@ def test_token_db(backend):
 
     if backend == "sqlite":
         yield token_manager.SQLiteTokenDB(db_location, keyfile)
-        os.remove(keyfile)
-    elif backend == "sqlitedict":
+    else:  # if backend == "sqlitedict":
         yield token_manager.SQLiteDictTokenDB(db_location, keyfile)
-        os.remove(keyfile)
-    else:  # backend == "shelve":
-        yield token_manager.ShelveTokenDB(db_location)
 
+    os.remove(keyfile)
     os.remove(f"{backend}_{db_location}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,8 @@ from .configs import (
     CONFIG_DOC_ENABLED,
     CONFIG_INVALID,
     CONFIG_NOT_SUPPORTED,
+    CONFIG_OTP_NOT_SUPPORTED,
+    CONFIG_OTP_SUPPORTED,
 )
 
 
@@ -87,3 +89,19 @@ def test_invalid_config(test_config):
 )
 def test_docs_url(test_config, config_parser, docs_url):
     assert test_config.Config(config_parser).docs_url == docs_url
+
+
+@pytest.mark.parametrize(
+    "config_parser,use_otp",
+    [
+        (CONFIG_NOT_SUPPORTED, False),
+        (CONFIG_OTP_NOT_SUPPORTED, False),
+        (CONFIG_OTP_SUPPORTED, True),
+    ],
+)
+def test_otp(test_config, config_parser, use_otp):
+    otp_config = test_config.Config(config_parser).otp
+    assert otp_config.use_otp == use_otp
+    assert otp_config.backend == "sqlite"
+    assert otp_config.db_location == "/run/motley_cue/tokenmap.db"
+    assert otp_config.keyfile == "/run/motley_cue/motley_cue.key"

--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -1,0 +1,210 @@
+import pytest
+import os
+import string
+from cryptography.fernet import Fernet
+from fastapi import Request
+
+from .utils import (
+    MOCK_TOKEN,
+    MOCK_REQUEST,
+    MOCK_HEADERS,
+    MOCK_OTP,
+    MOCK_OTP_REQUEST,
+    MOCK_OTP_HEADERS,
+    mock_exception,
+)
+
+
+def test_encryption(test_encryption):
+    keyfile = "tmp_keyfile"
+    secret = "this is my secret string to be encrypted"
+
+    encryption = test_encryption(keyfile)
+    assert oct(os.stat(keyfile).st_mode & 0o777) == "0o600"
+    assert secret == encryption.decrypt(encryption.encrypt(secret))
+
+    os.remove(keyfile)
+
+
+def test_encryption_keyfile_exists(test_encryption):
+    keyfile = "tmp_keyfile"
+    secret = "this is my secret string to be encrypted"
+
+    key = Fernet.generate_key()
+    open(keyfile, "wb").write(key)
+
+    encryption = test_encryption(keyfile)
+    assert secret == encryption.decrypt(encryption.encrypt(secret))
+
+    os.remove(keyfile)
+
+
+def test_encryption_keyfile_exists_not_a_key(test_encryption):
+    keyfile = "tmp_keyfile"
+
+    open(keyfile, "wb").write(b"random not a key")
+
+    with pytest.raises(Exception):
+        _ = test_encryption(keyfile)
+
+    os.remove(keyfile)
+
+
+def test_encryption_keyfile_exists_not_bytes(test_encryption):
+    keyfile = "tmp_keyfile"
+
+    open(keyfile, "w").write("random not a key")
+
+    with pytest.raises(Exception):
+        _ = test_encryption(keyfile)
+
+    os.remove(keyfile)
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["", "random string", 100 * "super long string "],
+    ids=["", "random string", "super long string"],
+)
+def test_token_manager_new_otp(test_token_manager_original_new_otp, token):
+    otp = test_token_manager_original_new_otp._new_otp(token)
+    assert len(otp) == 128
+    assert all(c in string.hexdigits for c in otp)
+
+
+def test_token_manager_generate_otp(test_token_manager):
+    assert test_token_manager.generate_otp(MOCK_TOKEN) == {
+        "supported": True,
+        "successful": True,
+    }
+
+
+def test_token_manager_generate_otp_fail(test_token_manager, monkeypatch):
+    monkeypatch.setattr(test_token_manager.db, "store", mock_exception)
+    assert test_token_manager.generate_otp(MOCK_TOKEN) == {
+        "supported": True,
+        "successful": False,
+    }
+
+
+def test_token_manager_get_token_fail(test_token_manager, monkeypatch):
+    monkeypatch.setattr(test_token_manager.db, "pop", mock_exception)
+    test_token_manager.generate_otp(MOCK_TOKEN)
+    assert test_token_manager.get_token(MOCK_OTP) == None
+
+
+async def test_token_manager_inject_token_not_in_kwargs(test_token_manager):
+    @test_token_manager.inject_token
+    async def mock_func(arg1: str, arg2: str):
+        return {"arg1": arg1, "arg2": arg2}
+
+    test_token_manager.generate_otp(MOCK_TOKEN)
+    result = await mock_func(arg1=MOCK_TOKEN, arg2=MOCK_OTP)
+    assert result["arg1"] == MOCK_TOKEN
+    assert result["arg2"] == MOCK_OTP
+
+
+async def test_token_manager_inject_token_replace_otp(test_token_manager):
+    @test_token_manager.inject_token
+    async def mock_func(request: Request, header: str):
+        request_token = None
+        header_token = None
+        request_header = request.headers.get("authorization", None)
+        if request_header and request_header.startswith("Bearer "):
+            request_token = request_header.lstrip("Bearer ")
+        if header and header.startswith("Bearer "):
+            header_token = header.lstrip("Bearer ")
+        return {"request_token": request_token, "header_token": header_token}
+
+    test_token_manager.generate_otp(MOCK_TOKEN)
+    result = await mock_func(
+        request=MOCK_OTP_REQUEST, header=MOCK_OTP_HEADERS["Authorization"]
+    )
+    assert result["request_token"] == MOCK_TOKEN
+    assert result["header_token"] == MOCK_TOKEN
+
+
+async def test_token_manager_inject_token_keep_at(test_token_manager):
+    @test_token_manager.inject_token
+    async def mock_func(request: Request, header: str):
+        request_token = None
+        header_token = None
+        request_header = request.headers.get("authorization", None)
+        if request_header and request_header.startswith("Bearer "):
+            request_token = request_header.lstrip("Bearer ")
+        if header and header.startswith("Bearer "):
+            header_token = header.lstrip("Bearer ")
+        return {"request_token": request_token, "header_token": header_token}
+
+    test_token_manager.generate_otp(MOCK_TOKEN)
+    result = await mock_func(request=MOCK_REQUEST, header=MOCK_HEADERS["Authorization"])
+    assert result["request_token"] == MOCK_TOKEN
+    assert result["header_token"] == MOCK_TOKEN
+
+
+@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict", "shelve"])
+def test_token_db_empty(test_token_db):
+    mock_otp = "mock_otp"
+
+    assert test_token_db.get(mock_otp) == None
+    assert test_token_db.pop(mock_otp) == None
+
+
+@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict", "shelve"])
+def test_token_db_insert(test_token_db):
+    mock_otp = "mock_otp"
+    mock_at = "mock_at"
+
+    test_token_db.insert(mock_otp, mock_at)
+    assert test_token_db.get(mock_otp) == mock_at
+    assert test_token_db.get(mock_otp) == mock_at
+
+
+@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict", "shelve"])
+def test_token_db_remove(test_token_db):
+    mock_otp = "mock_otp"
+    mock_at = "mock_at"
+
+    test_token_db.insert(mock_otp, mock_at)
+    test_token_db.remove(mock_otp)
+    assert test_token_db.get(mock_otp) == None
+
+
+@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict", "shelve"])
+def test_token_db_pop(test_token_db):
+    mock_otp = "mock_otp"
+    mock_at = "mock_at"
+
+    test_token_db.insert(mock_otp, mock_at)
+    assert test_token_db.pop(mock_otp) == mock_at
+    assert test_token_db.get(mock_otp) == None
+
+
+@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict", "shelve"])
+def test_token_db_store(test_token_db):
+    mock_otp = "mock_otp"
+    mock_at = "mock_at"
+
+    assert test_token_db.store(mock_otp, mock_at) == True
+    assert test_token_db.get(mock_otp) == mock_at
+
+
+@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict", "shelve"])
+def test_token_db_store_twice(test_token_db):
+    mock_otp = "mock_otp"
+    mock_at = "mock_at"
+
+    # test store twice
+    assert test_token_db.store(mock_otp, mock_at) == True
+    assert test_token_db.store(mock_otp, mock_at) == True
+    assert test_token_db.get(mock_otp) == mock_at
+
+
+@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict", "shelve"])
+def test_token_db_store_collision(test_token_db):
+    mock_otp = "mock_otp"
+    mock_at = "mock_at"
+
+    assert test_token_db.store(mock_otp, mock_at) == True
+    assert test_token_db.store(mock_otp, "another at") == False
+    assert test_token_db.get(mock_otp) == mock_at

--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -142,7 +142,7 @@ async def test_token_manager_inject_token_keep_at(test_token_manager):
     assert result["header_token"] == MOCK_TOKEN
 
 
-@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict", "shelve"])
+@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict"])
 def test_token_db_empty(test_token_db):
     mock_otp = "mock_otp"
 
@@ -150,7 +150,7 @@ def test_token_db_empty(test_token_db):
     assert test_token_db.pop(mock_otp) == None
 
 
-@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict", "shelve"])
+@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict"])
 def test_token_db_insert(test_token_db):
     mock_otp = "mock_otp"
     mock_at = "mock_at"
@@ -160,7 +160,7 @@ def test_token_db_insert(test_token_db):
     assert test_token_db.get(mock_otp) == mock_at
 
 
-@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict", "shelve"])
+@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict"])
 def test_token_db_remove(test_token_db):
     mock_otp = "mock_otp"
     mock_at = "mock_at"
@@ -170,7 +170,7 @@ def test_token_db_remove(test_token_db):
     assert test_token_db.get(mock_otp) == None
 
 
-@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict", "shelve"])
+@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict"])
 def test_token_db_pop(test_token_db):
     mock_otp = "mock_otp"
     mock_at = "mock_at"
@@ -180,7 +180,7 @@ def test_token_db_pop(test_token_db):
     assert test_token_db.get(mock_otp) == None
 
 
-@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict", "shelve"])
+@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict"])
 def test_token_db_store(test_token_db):
     mock_otp = "mock_otp"
     mock_at = "mock_at"
@@ -189,7 +189,7 @@ def test_token_db_store(test_token_db):
     assert test_token_db.get(mock_otp) == mock_at
 
 
-@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict", "shelve"])
+@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict"])
 def test_token_db_store_twice(test_token_db):
     mock_otp = "mock_otp"
     mock_at = "mock_at"
@@ -200,7 +200,7 @@ def test_token_db_store_twice(test_token_db):
     assert test_token_db.get(mock_otp) == mock_at
 
 
-@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict", "shelve"])
+@pytest.mark.parametrize("backend", ["sqlite", "sqlitedict"])
 def test_token_db_store_collision(test_token_db):
     mock_otp = "mock_otp"
     mock_at = "mock_at"


### PR DESCRIPTION
Meant as a (first try) fix for #33.

**TL;DR** For long access tokens, hash AT and use hash as an SSH password instead of AT. Maintain a mapping between hash and AT in `motley_cue`, to be able to retrieve all information about the user from hash at all times.

**How it works in more detail:**
- add an endpoint `/user/generate_otp` that triggers the generation of a one-time password (OTP):
  - OTP of fixed length (128 chars) is obtained by hashing AT => can be done independently on client side
  - OTP - AT mapping is stored in a local database
  - response from this endpoint contains whether OTPs are supported, and whether the generation was successful, e.g.:
  ```
  {
    "supported": True,
    "successful": True
  }
  ``` 
- motley_cue maintains a lightweight database for mapping OTP to AT
  - DB is encrypted
  - uses file db (sqlite/sqlitedict) s.t. no additional DB server has to be maintained
- when `/verify_user` is called with an OTP as bearer token
  - OTP is replaced with corresponding AT from database
  - mapping is removed from database (one-time behaviour)
  - `/verify_user` with AT will still work normally as before
  - reason: `/verify_user` is always called by PAM with token provided to SSH as password 
- `mccli` will have to provide OTP when prompted instead of AT

**TODO**: decide on backend to use based on performance & security differences between `sqlite` and `sqlitedict` (no real need to offer this option to admins).